### PR TITLE
Allow traffic from all hosts

### DIFF
--- a/big_brother/settings.py
+++ b/big_brother/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'vqxp9bygt0akc-qbf&j_3#yr2%u44iv29fkau%&a%3+wr+^kxr'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition


### PR DESCRIPTION
In order to test from mobile devices on local networks wildcard should be used.

The other method is to set white-list IP addresses which is sub optimal in this project and highly unneeded. 